### PR TITLE
Upgrade data-of-loathing to v3.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@react-router/serve": "^7.14.1",
     "@tanstack/react-table": "^8.21.3",
     "commander": "^14.0.3",
-    "data-of-loathing": "^2.6.2",
+    "data-of-loathing": "^3.2.2",
     "feed": "^5.2.1",
     "isbot": "^5.1.39",
     "kol.js": "^0.7.0",

--- a/scripts/utils/client.ts
+++ b/scripts/utils/client.ts
@@ -368,7 +368,7 @@ export async function updateClasses() {
       if (knownClass.name === "None") continue;
 
       // Only set pathId if that path is already in our database
-      const pathId = knownClass.path && existingPathIds.has(knownClass.path) ? knownClass.path : null;
+      const pathId = knownClass.path?.id != null && existingPathIds.has(knownClass.path.id) ? knownClass.path.id : null;
 
       await trx
         .updateTable("Class")

--- a/scripts/utils/data.ts
+++ b/scripts/utils/data.ts
@@ -1,20 +1,12 @@
-import { createClient } from "data-of-loathing";
+import { AscensionClass, Path, createClient } from "data-of-loathing";
 
 const client = createClient();
+const loaded = client.load();
 
 export async function fetchPaths() {
   try {
-    const data = await client.query({
-      allPaths: {
-        nodes: {
-          id: true,
-          image: true,
-          name: true,
-        },
-      },
-    });
-
-    return data.allPaths?.nodes.filter((n) => n !== null) ?? [];
+    await loaded;
+    return await client.query.find(Path, {}, { orderBy: { id: "ASC" } });
   } catch (error) {
     console.error(error);
     return null;
@@ -23,18 +15,8 @@ export async function fetchPaths() {
 
 export async function fetchClasses() {
   try {
-    const data = await client.query({
-      allClasses: {
-        nodes: {
-          id: true,
-          image: true,
-          name: true,
-          path: true,
-        },
-      },
-    });
-
-    return data.allClasses?.nodes.filter((n) => n !== null) ?? [];
+    await loaded;
+    return await client.query.find(AscensionClass, {}, { orderBy: { id: "ASC" }, populate: ["path"] });
   } catch (error) {
     console.error(error);
     return null;

--- a/yarn.lock
+++ b/yarn.lock
@@ -990,6 +990,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mikro-orm/core@npm:^7.0.14":
+  version: 7.0.15
+  resolution: "@mikro-orm/core@npm:7.0.15"
+  peerDependencies:
+    dataloader: 2.2.3
+  peerDependenciesMeta:
+    dataloader:
+      optional: true
+  checksum: 10c0/9dd237c086ef9603f336156557181dcaaa4a74f865b5795dce86f14655832d936186dee011fbb38b7086477e6f6cb13be25cd3bac9c2c62fb80cf306028f6207
+  languageName: node
+  linkType: hard
+
+"@mikro-orm/sql@npm:^7.0.14":
+  version: 7.0.15
+  resolution: "@mikro-orm/sql@npm:7.0.15"
+  dependencies:
+    kysely: "npm:0.28.17"
+  peerDependencies:
+    "@mikro-orm/core": 7.0.15
+  checksum: 10c0/1d7aacccd2da0d80e954367b427253f47dc4a23f4ff4fed14fc69f05a66c0ada97e29a0ed4aab58a4e073684f461eab8600fbee485a60264a73a576360ccac1e
+  languageName: node
+  linkType: hard
+
 "@mjackson/node-fetch-server@npm:^0.2.0":
   version: 0.2.0
   resolution: "@mjackson/node-fetch-server@npm:0.2.0"
@@ -1463,6 +1486,13 @@ __metadata:
   version: 4.60.2
   resolution: "@rollup/rollup-win32-x64-msvc@npm:4.60.2"
   conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@sqlite.org/sqlite-wasm@npm:~3.51.2-build9":
+  version: 3.51.2-build9
+  resolution: "@sqlite.org/sqlite-wasm@npm:3.51.2-build9"
+  checksum: 10c0/2b9c4d3df7b2cf84c1b311ac276c19692d8ccad4a4b34a1a739e1eb3b8938c6be4e64a98d51b7ea6e9ad5000a912d4ed0c25eec146f7eb468fa343b7ce491a08
   languageName: node
   linkType: hard
 
@@ -3620,10 +3650,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"data-of-loathing@npm:^2.6.2":
-  version: 2.6.2
-  resolution: "data-of-loathing@npm:2.6.2"
-  checksum: 10c0/160be95e0886d797ddde79d25285cd3a09861097ac9131b7ceb5f2119648ba31d5d0ed1322e31a607140e9b610580095b95b4b6f72057790e12b1abd67ecbc17
+"data-of-loathing@npm:^3.2.2":
+  version: 3.2.2
+  resolution: "data-of-loathing@npm:3.2.2"
+  dependencies:
+    "@mikro-orm/core": "npm:^7.0.14"
+    "@mikro-orm/sql": "npm:^7.0.14"
+    "@sqlite.org/sqlite-wasm": "npm:~3.51.2-build9"
+    env-paths: "npm:^4.0.0"
+    kysely: "npm:^0.28.17"
+  peerDependencies:
+    vite: ">=5.0.0"
+    vite-plugin-node-polyfills: ^0.26.0
+  peerDependenciesMeta:
+    vite:
+      optional: true
+    vite-plugin-node-polyfills:
+      optional: true
+  checksum: 10c0/c2238b96ef4be0e8c3384ca205ba80cb9b54e2c8e92d09c6d85f5fba0de316bfff642e899fbac874869ff32f50cac0b74bccbfeaec0d542f740f4c16384c832e
   languageName: node
   linkType: hard
 
@@ -3891,6 +3935,15 @@ __metadata:
   version: 2.2.1
   resolution: "env-paths@npm:2.2.1"
   checksum: 10c0/285325677bf00e30845e330eec32894f5105529db97496ee3f598478e50f008c5352a41a30e5e72ec9de8a542b5a570b85699cd63bd2bc646dbcb9f311d83bc4
+  languageName: node
+  linkType: hard
+
+"env-paths@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "env-paths@npm:4.0.0"
+  dependencies:
+    is-safe-filename: "npm:^0.1.0"
+  checksum: 10c0/13ee7fa4047786ca28f1fbf2239606f8a53304bdf71bfc426e95f806e429060181205316f2c45b4ac560e81c854ded5a45fd9dc3105414c01d504b3469a1294b
   languageName: node
   linkType: hard
 
@@ -5068,6 +5121,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-safe-filename@npm:^0.1.0":
+  version: 0.1.1
+  resolution: "is-safe-filename@npm:0.1.1"
+  checksum: 10c0/45c35d2253b96348e2c26590e14feed51d1e6b72aaa567930ccb34e68c0eef00ebcf3b7e01b46bf45e578a27355cd8f5bc12f7d6d79a34d33dc93d4560c0f6b6
+  languageName: node
+  linkType: hard
+
 "is-set@npm:^2.0.3":
   version: 2.0.3
   resolution: "is-set@npm:2.0.3"
@@ -5356,6 +5416,13 @@ __metadata:
   bin:
     kysely: dist/bin.mjs
   checksum: 10c0/7588a1663c90e8c7b5943b19a7c91e78e4e83d7d1ab9f314af44e2734172cbb5e772a1807d8599f3ae29ca2172db5c4c38d9ef4d5a67280db6c7cceefdd2e7cc
+  languageName: node
+  linkType: hard
+
+"kysely@npm:0.28.17, kysely@npm:^0.28.17":
+  version: 0.28.17
+  resolution: "kysely@npm:0.28.17"
+  checksum: 10c0/70573292d8d60a1e29be9b432c1b25fe21d4806ecd5e9859b5ba8d2af799769878f4b3d91731ffe3e03744c7291476fe843640d31741f3637e20c3c49afea3c5
   languageName: node
   linkType: hard
 
@@ -6830,7 +6897,7 @@ __metadata:
     "@types/react-dom": "npm:^19.2.3"
     autoprefixer: "npm:^10.5.0"
     commander: "npm:^14.0.3"
-    data-of-loathing: "npm:^2.6.2"
+    data-of-loathing: "npm:^3.2.2"
     eslint: "npm:^10.2.1"
     eslint-plugin-react: "npm:^7.37.5"
     feed: "npm:^5.2.1"


### PR DESCRIPTION
Upgrades `data-of-loathing` from v2.6.2 to v3.2.2.

v3 replaces the GenQL/GraphQL client with an embedded SQLite database via MikroORM. The DB is downloaded once (ETag-cached) and queried locally.

## Changes

- `data.ts`: migrate to v3 query API — `client.load()` on startup, `client.query.find()` with entity classes instead of GraphQL field-selection objects
- `client.ts`: `AscensionClass.path` is now a `Path` relation object in v3 (was an integer in v2), so update the pathId lookup to use `.path?.id`